### PR TITLE
[WIP] LDAP SCIM bridge daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bridge.db

--- a/cmd/ldap-bridged/internal/db/users.go
+++ b/cmd/ldap-bridged/internal/db/users.go
@@ -201,8 +201,8 @@ func (u *Users) Add(dn string, user scim.User) error {
 	return nil
 }
 
-// Delete ...
-func (u *Users) Delete(user User) error {
+// Del ...
+func (u *Users) Del(guid, dn string) error {
 	// Start the transaction.
 	tx, err := u.db.Begin(true)
 	if err != nil {
@@ -217,11 +217,11 @@ func (u *Users) Delete(user User) error {
 	dnIdx := root.Bucket([]byte(dnIdxBucketName))
 
 	// remove membership
-	members.Delete([]byte(user.GUID))
+	members.Delete([]byte(guid))
 
 	// clear indexes
-	dnIdx.Delete([]byte(user.DN))
-	guidIdx.Delete([]byte(user.GUID))
+	dnIdx.Delete([]byte(dn))
+	guidIdx.Delete([]byte(guid))
 
 	// Commit the transaction.
 	if err := tx.Commit(); err != nil {

--- a/cmd/ldap-bridged/internal/db/users.go
+++ b/cmd/ldap-bridged/internal/db/users.go
@@ -1,0 +1,192 @@
+package users
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/boltdb/bolt"
+	scim "github.com/mtodd/scimtool"
+)
+
+/*
+
+# Database structure
+
+## Members
+
+* state(?)
+* guid (key)
+* userName
+* firstName
+* lastName
+* email
+
+## Indexes
+
+* dn-to-guid
+* guid-to-dn
+
+*/
+
+// User ...
+type User struct {
+	DN        string
+	GUID      string
+	UserName  string
+	FirstName string
+	LastName  string
+	Email     string
+}
+
+// Users ...
+type Users struct {
+	store   string
+	db      *bolt.DB
+	root    *bolt.Bucket
+	members *bolt.Bucket
+	dnIdx   *bolt.Bucket
+	guidIdx *bolt.Bucket
+}
+
+// New ...
+func New(db *bolt.DB) Users {
+	return Users{
+		store: "ldap-scim",
+		db:    db,
+	}
+}
+
+// Prepare ...
+func (u *Users) Prepare() error {
+	// Start the transaction.
+	tx, err := u.db.Begin(true)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	// create the root IdP bucket.
+	root, err := tx.CreateBucketIfNotExists([]byte(u.store))
+	if err != nil {
+		return fmt.Errorf("create ldap-scim bucket: %s", err)
+	}
+
+	// create membership bucket
+	mb, err := root.CreateBucketIfNotExists([]byte("members"))
+	if err != nil {
+		return fmt.Errorf("create members bucket: %s", err)
+	}
+
+	// create DN-to-GUID index
+	guids, err := root.CreateBucketIfNotExists([]byte("guids"))
+	if err != nil {
+		return fmt.Errorf("create guids index bucket: %s", err)
+	}
+
+	// create GUID-to-DN index
+	dns, err := root.CreateBucketIfNotExists([]byte("dns"))
+	if err != nil {
+		return fmt.Errorf("create dns bucket: %s", err)
+	}
+
+	u.root = root
+	u.members = mb
+	u.guidIdx = guids
+	u.dnIdx = dns
+
+	// Commit the transaction.
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetGUID ...
+func (u *Users) GetGUID(dn string) (string, error) {
+	guid := u.dnIdx.Get([]byte(dn))
+	if len(guid) == 0 {
+		return "", fmt.Errorf("GetGUID(%s) failed: not found", dn)
+	}
+	return string(guid), nil
+}
+
+// GetDN ...
+func (u *Users) GetDN(guid string) (string, error) {
+	dn := u.guidIdx.Get([]byte(guid))
+	if len(dn) == 0 {
+		return "", fmt.Errorf("GetDN(%s) failed: not found", guid)
+	}
+	return string(dn), nil
+}
+
+// GetMemberDNs ...
+func (u *Users) GetMemberDNs() ([]string, error) {
+	dns := []string{}
+	u.guidIdx.ForEach(func(k []byte, v []byte) error {
+		dns = append(dns, string(k))
+		return nil
+	})
+	return nil, nil
+}
+
+// Add ...
+func (u *Users) Add(dn string, user scim.User) error {
+	// Start the transaction.
+	tx, err := u.db.Begin(true)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	dnb := []byte(dn)
+	guid := []byte(user.ID)
+
+	// Retrieve the root->members bucket.
+	root := tx.Bucket([]byte("ldap-scim"))
+	members := root.Bucket([]byte("members"))
+	guidIdx := root.Bucket([]byte("guids"))
+	dnIdx := root.Bucket([]byte("dns"))
+
+	// Marshal and save the encoded user.
+	if buf, err := json.Marshal(u); err != nil {
+		return err
+	} else if err := members.Put(guid, buf); err != nil {
+		return err
+	}
+
+	// write GUID-to-DN index
+	if err := guidIdx.Put(guid, dnb); err != nil {
+		return fmt.Errorf("index guid(%s, %s): %s", guid, dn, err)
+	}
+
+	// write DN-to-GUID index
+	if err := dnIdx.Put(dnb, guid); err != nil {
+		return fmt.Errorf("index dn(%s, %s): %s", dn, guid, err)
+	}
+
+	// Commit the transaction.
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete ...
+func (u *Users) Delete(user User) error {
+	if err := u.db.Update(func(tx *bolt.Tx) error {
+		// remove membership
+		u.members.Delete([]byte(user.GUID))
+
+		// clear indexes
+		u.dnIdx.Delete([]byte(user.DN))
+		u.guidIdx.Delete([]byte(user.GUID))
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/ldap-bridged/internal/db/users.go
+++ b/cmd/ldap-bridged/internal/db/users.go
@@ -104,19 +104,37 @@ func (u *Users) Prepare() error {
 
 // GetGUID ...
 func (u *Users) GetGUID(dn string) (string, error) {
-	guid := u.dnIdx.Get([]byte(dn))
-	if len(guid) == 0 {
-		return "", fmt.Errorf("GetGUID(%s) failed: not found", dn)
+	tx, err := u.db.Begin(false)
+	if err != nil {
+		return "", err
 	}
+	defer tx.Rollback()
+
+	root := tx.Bucket([]byte("ldap-scim"))
+	dnIdx := root.Bucket([]byte("dns"))
+
+	guid := dnIdx.Get([]byte(dn))
+	// if len(guid) == 0 {
+	// 	return "", fmt.Errorf("GetGUID(%s) failed: not found", dn)
+	// }
 	return string(guid), nil
 }
 
 // GetDN ...
 func (u *Users) GetDN(guid string) (string, error) {
-	dn := u.guidIdx.Get([]byte(guid))
-	if len(dn) == 0 {
-		return "", fmt.Errorf("GetDN(%s) failed: not found", guid)
+	tx, err := u.db.Begin(false)
+	if err != nil {
+		return "", err
 	}
+	defer tx.Rollback()
+
+	root := tx.Bucket([]byte("ldap-scim"))
+	guidIdx := root.Bucket([]byte("guids"))
+
+	dn := guidIdx.Get([]byte(guid))
+	// if len(dn) == 0 {
+	// 	return "", fmt.Errorf("GetDN(%s) failed: not found", guid)
+	// }
 	return string(dn), nil
 }
 

--- a/cmd/ldap-bridged/internal/db/users.go
+++ b/cmd/ldap-bridged/internal/db/users.go
@@ -163,7 +163,7 @@ func (u *Users) Add(dn string, user scim.User) error {
 	// Start the transaction.
 	tx, err := u.db.Begin(true)
 	if err != nil {
-		return err
+		return fmt.Errorf("begin: %s", err)
 	}
 	defer tx.Rollback()
 
@@ -178,9 +178,9 @@ func (u *Users) Add(dn string, user scim.User) error {
 
 	// Marshal and save the encoded user.
 	if buf, err := json.Marshal(user); err != nil {
-		return err
+		return fmt.Errorf("json marshal user(%s): %s", guid, err)
 	} else if err := members.Put(guid, buf); err != nil {
-		return err
+		return fmt.Errorf("persist member(%s): %s", guid, err)
 	}
 
 	// write GUID-to-DN index
@@ -195,7 +195,7 @@ func (u *Users) Add(dn string, user scim.User) error {
 
 	// Commit the transaction.
 	if err := tx.Commit(); err != nil {
-		return err
+		return fmt.Errorf("commit: %s", err)
 	}
 
 	return nil

--- a/cmd/ldap-bridged/internal/db/users.go
+++ b/cmd/ldap-bridged/internal/db/users.go
@@ -149,7 +149,7 @@ func (u *Users) Add(dn string, user scim.User) error {
 	dnIdx := root.Bucket([]byte("dns"))
 
 	// Marshal and save the encoded user.
-	if buf, err := json.Marshal(u); err != nil {
+	if buf, err := json.Marshal(user); err != nil {
 		return err
 	} else if err := members.Put(guid, buf); err != nil {
 		return err

--- a/cmd/ldap-bridged/internal/idp/main.go
+++ b/cmd/ldap-bridged/internal/idp/main.go
@@ -1,0 +1,202 @@
+package idp
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/mtodd/ldapwatch"
+
+	ldap "gopkg.in/ldap.v2"
+)
+
+// LDAPProvider ...
+type LDAPProvider struct {
+	conn    *ldap.Conn
+	Added   chan string
+	Removed chan string
+	done    chan struct{}
+}
+
+// NewLDAPProvider ...
+func NewLDAPProvider(conn *ldap.Conn) LDAPProvider {
+	return LDAPProvider{
+		conn:    conn,
+		Added:   make(chan string),
+		Removed: make(chan string),
+		done:    make(chan struct{}),
+	}
+}
+
+// Start ...
+func (p *LDAPProvider) Start() error {
+	updates := make(chan event)
+	done := make(chan struct{})
+	// defer func() { close(done) }()
+	go handleUpdates(p, updates, done)
+
+	w, err := ldapwatch.NewWatcher(p.conn, 1*time.Second, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// defer w.Stop()
+
+	c := groupMembershipChecker{
+		c: updates,
+	}
+
+	// Search to monitor for changes
+	searchRequest := ldap.NewSearchRequest(
+		"ou=people,dc=planetexpress,dc=com",
+		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+		// "(cn=ship_crew)",
+		"(cn=test_group)",
+		[]string{"*", "modifyTimestamp"},
+		nil,
+	)
+
+	// register the search
+	w.Add(searchRequest, &c)
+
+	w.Start()
+
+	return nil
+}
+
+type event struct {
+	before *ldap.Entry
+	after  *ldap.Entry
+}
+
+// Implements the ldapwatch.Checker interface in order to check whether
+// the search results change over time.
+//
+// In this case, our Checker keeps track of previous results as well as
+// holding a channel that we notify whenever changes are detected.
+type groupMembershipChecker struct {
+	prev *ldap.SearchResult
+	c    chan event
+}
+
+// Check receives the result of the search; the Checker needs to take action
+// if the result does not match what it expects.
+func (c *groupMembershipChecker) Check(r *ldap.SearchResult, err error) {
+	if err != nil {
+		log.Printf("%s", err)
+		return
+	}
+
+	// first search sets baseline
+	if c.prev == nil {
+		c.prev = r
+		r.PrettyPrint(2)
+		return
+	}
+
+	if len(c.prev.Entries) != len(r.Entries) {
+		// entries returned does not match
+		c.prev = r
+		return
+	}
+
+	prevEntry := c.prev.Entries[0]
+	nextEntry := r.Entries[0]
+
+	if prevEntry.GetAttributeValue("modifyTimestamp") != nextEntry.GetAttributeValue("modifyTimestamp") {
+		// modifyTimestamp changed
+		c.prev = r
+		c.c <- event{prevEntry, nextEntry}
+		return
+	}
+
+	// no change
+}
+
+type changes struct {
+	added   []string
+	removed []string
+}
+
+func computeChanges(before *ldap.Entry, after *ldap.Entry) changes {
+	c := changes{}
+
+	bs := make(map[string]bool, len(before.GetAttributeValues("member")))
+	as := make(map[string]bool, len(after.GetAttributeValues("member")))
+
+	for _, dn := range before.GetAttributeValues("member") {
+		bs[dn] = true
+	}
+	for _, dn := range after.GetAttributeValues("member") {
+		as[dn] = true
+	}
+
+	added := make(map[string]bool, len(before.GetAttributeValues("member")))
+	removed := make(map[string]bool, len(after.GetAttributeValues("member")))
+
+	for dn := range as {
+		// everything in the after list could've been added
+		added[dn] = true
+	}
+	for dn := range bs {
+		// it wasn't added if it was in the before list, so remove it
+		delete(added, dn)
+	}
+
+	for dn := range added {
+		c.added = append(c.added, dn)
+	}
+
+	for dn := range bs {
+		// everything in the before list could've been removed
+		removed[dn] = true
+	}
+	for dn := range as {
+		// it wasn't removed if it was in the after list, so remove it
+		delete(removed, dn)
+	}
+
+	for dn := range removed {
+		c.removed = append(c.removed, dn)
+	}
+
+	return c
+}
+
+func handleUpdates(p *LDAPProvider, c chan event, done chan struct{}) {
+	for {
+		select {
+		case e := <-c:
+			before := e.before
+			after := e.after
+			log.Printf("change detected: %s", after.DN)
+			c := computeChanges(before, after)
+			log.Printf("%+v", c)
+			for _, dn := range c.added {
+				p.Added <- dn
+			}
+			for _, dn := range c.removed {
+				p.Removed <- dn
+			}
+		case <-done:
+			return
+		}
+	}
+}
+
+// Fetch ...
+func (p *LDAPProvider) Fetch(dn string) (*ldap.Entry, error) {
+	req := ldap.NewSearchRequest(
+		dn,
+		ldap.ScopeBaseObject, ldap.NeverDerefAliases, 0, 0, false,
+		"(objectClass=*)",
+		[]string{"dn", "uid", "cn", "sn", "givenName", "mail", "modifyTimestamp"},
+		nil,
+	)
+
+	res, err := p.conn.Search(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch failed: %s", err)
+	}
+
+	return res.Entries[0], nil
+}

--- a/cmd/ldap-bridged/internal/sp/main.go
+++ b/cmd/ldap-bridged/internal/sp/main.go
@@ -8,6 +8,8 @@ import (
 	scim "github.com/mtodd/scimtool"
 )
 
+// scim "github.com/imulab/go-scim/shared"
+
 // SCIMProvider ...
 type SCIMProvider struct {
 	store map[string]scim.User
@@ -22,9 +24,6 @@ func NewSCIMProvider() SCIMProvider {
 
 // Add ...
 func (sp *SCIMProvider) Add(u scim.User) (string, error) {
-	// guid := "meow"
-	// uid := rand.Int63()
-	// guid := strconv.FormatInt(uid, 64)
 	h := sha256.New()
 	h.Write([]byte(u.UserName))
 	guid := base64.StdEncoding.EncodeToString(h.Sum(nil))

--- a/cmd/ldap-bridged/internal/sp/main.go
+++ b/cmd/ldap-bridged/internal/sp/main.go
@@ -1,29 +1,26 @@
 package sp
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"log"
+	"net/http"
+	"os"
 
 	scim "github.com/mtodd/scimtool"
 )
 
-// scim "github.com/imulab/go-scim/shared"
+const defaultBaseURL = "https://api.github.com"
 
-// SCIMProvider ...
-type SCIMProvider struct {
+type fakeAPIClient struct {
 	store map[string]scim.User
 }
 
-// NewSCIMProvider ...
-func NewSCIMProvider() SCIMProvider {
-	return SCIMProvider{
-		store: make(map[string]scim.User),
-	}
-}
-
-// Add ...
-func (sp *SCIMProvider) Add(u scim.User) (string, error) {
+func (c *fakeAPIClient) Add(u scim.User) (string, error) {
 	h := sha256.New()
 	h.Write([]byte(u.UserName))
 	guid := base64.StdEncoding.EncodeToString(h.Sum(nil))
@@ -31,26 +28,251 @@ func (sp *SCIMProvider) Add(u scim.User) (string, error) {
 	log.Printf("scim: adding %s as %s", u.UserName, guid)
 
 	u.ID = guid
-	sp.store[guid] = u
+	c.store[guid] = u
+
+	return "", nil
+}
+
+func (c *fakeAPIClient) Del(guid string) error {
+	log.Printf("scim: removing %s", guid)
+
+	delete(c.store, guid)
+
+	return nil
+}
+
+func (c *fakeAPIClient) List() ([]scim.User, error) {
+	list := make([]scim.User, len(c.store))
+
+	for _, user := range c.store {
+		list = append(list, user)
+	}
+
+	return list, nil
+}
+
+type apiClient struct {
+	client  *http.Client
+	baseURL string
+	token   string
+	org     string
+	debug   bool
+}
+
+func (c *apiClient) buildRequest(method, endpoint string) (*http.Request, error) {
+	req, err := http.NewRequest(method, c.buildEndpointURL(endpoint), nil)
+
+	req.Header.Set("Accept", "application/vnd.github.cloud-9-preview+json+scim")
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	if method == "POST" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	return req, err
+}
+
+func (c *apiClient) buildEndpointURL(path string) string {
+	return fmt.Sprintf("%s%s", c.baseURL, path)
+}
+
+func (c *apiClient) do(req *http.Request) (*http.Response, error) {
+	if c.debug {
+		log.Printf("debug: %v", req)
+	}
+
+	res, err := c.client.Do(req)
+
+	if c.debug && err == nil {
+		log.Printf("debug: %v", res)
+	}
+
+	return res, err
+}
+
+func (c *apiClient) Add(user scim.User) (string, error) {
+	req, err := c.buildRequest("POST", fmt.Sprintf("/scim/v2/organizations/%s/Users", c.org))
+	if err != nil {
+		return "", err
+	}
+
+	jsonBody, err := json.Marshal(user)
+	if err != nil {
+		return "", err
+	}
+
+	req.Body = ioutil.NopCloser(bytes.NewBufferString(string(jsonBody)))
+
+	res, err := c.do(req)
+	if err != nil {
+		return "", err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("remove failed: %v", res)
+	}
+
+	if c.debug {
+		log.Printf("debug: %v", string(body))
+	}
+
+	if err := json.Unmarshal(body, &user); err != nil {
+		return "", err
+	}
+
+	log.Printf("added: %s", user.ID)
+
+	return user.ID, nil
+}
+
+func (c *apiClient) Del(guid string) error {
+	req, err := c.buildRequest("DELETE", fmt.Sprintf("/scim/v2/organizations/%s/Users/%s", c.org, guid))
+	if err != nil {
+		return err
+	}
+
+	res, err := c.do(req)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("remove failed: %v", res)
+	}
+
+	log.Printf("removed %s", guid)
+	return nil
+}
+
+func (c *apiClient) List() ([]scim.User, error) {
+	req, err := c.buildRequest("GET", fmt.Sprintf("/scim/v2/organizations/%s/Users", c.org))
+	if err != nil {
+		return nil, err
+	}
+
+	// include filter query param if filter is given
+	// if len(filter) > 0 {
+	// 	q := req.URL.Query()
+	// 	q.Add("filter", filter)
+	// 	req.URL.RawQuery = q.Encode()
+	// }
+
+	res, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode == http.StatusBadRequest {
+		return nil, fmt.Errorf("list: bad request: %s", string(body))
+	}
+
+	if res.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("list: not found: %s", string(body))
+	}
+
+	if c.debug {
+		log.Printf("debug: %v", string(body))
+	}
+
+	var list scim.ListResponse
+	if err := json.Unmarshal(body, &list); err != nil {
+		return nil, err
+	}
+
+	return list.Resources, nil
+}
+
+type scimProvider interface {
+	Add(scim.User) (string, error)
+	Del(guid string) error
+	List() ([]scim.User, error)
+}
+
+// SCIMProvider ...
+type SCIMProvider struct {
+	client *scimProvider
+}
+
+// NewSCIMProvider ...
+func NewSCIMProvider() SCIMProvider {
+	// configuration
+	token := os.Getenv("TOKEN")
+
+	baseURL := os.Getenv("BASEURL")
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	org := os.Getenv("ORG")
+	if org == "" {
+		org = "idptool"
+	}
+
+	var client scimProvider
+
+	dry := true
+	if os.Getenv("DRY") == "no" {
+		dry = false
+	}
+
+	if dry {
+		client = &fakeAPIClient{
+			store: make(map[string]scim.User),
+		}
+	} else {
+		// HTTP client
+		client = &apiClient{
+			client:  &http.Client{},
+			baseURL: baseURL,
+			token:   token,
+			org:     org,
+		}
+	}
+
+	return SCIMProvider{
+		client: &client,
+	}
+}
+
+// Add ...
+func (sp *SCIMProvider) Add(u scim.User) (string, error) {
+	client := *sp.client
+	guid, err := client.Add(u)
+	if err != nil {
+		return "", err
+	}
 
 	return guid, nil
 }
 
 // Del ...
 func (sp *SCIMProvider) Del(guid string) error {
-	log.Printf("scim: removing %s", guid)
-
-	delete(sp.store, guid)
+	client := *sp.client
+	if err := client.Del(guid); err != nil {
+		return err
+	}
 
 	return nil
 }
 
 // List ...
 func (sp *SCIMProvider) List() ([]scim.User, error) {
-	list := make([]scim.User, len(sp.store))
-
-	for _, user := range sp.store {
-		list = append(list, user)
+	client := *sp.client
+	list, err := client.List()
+	if err != nil {
+		return nil, err
 	}
 
 	return list, nil

--- a/cmd/ldap-bridged/internal/sp/main.go
+++ b/cmd/ldap-bridged/internal/sp/main.go
@@ -30,7 +30,7 @@ func (c *fakeAPIClient) Add(u scim.User) (string, error) {
 	u.ID = guid
 	c.store[guid] = u
 
-	return "", nil
+	return guid, nil
 }
 
 func (c *fakeAPIClient) Del(guid string) error {

--- a/cmd/ldap-bridged/internal/sp/main.go
+++ b/cmd/ldap-bridged/internal/sp/main.go
@@ -1,0 +1,58 @@
+package sp
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"log"
+
+	scim "github.com/mtodd/scimtool"
+)
+
+// SCIMProvider ...
+type SCIMProvider struct {
+	store map[string]scim.User
+}
+
+// NewSCIMProvider ...
+func NewSCIMProvider() SCIMProvider {
+	return SCIMProvider{
+		store: make(map[string]scim.User),
+	}
+}
+
+// Add ...
+func (sp *SCIMProvider) Add(u scim.User) (string, error) {
+	// guid := "meow"
+	// uid := rand.Int63()
+	// guid := strconv.FormatInt(uid, 64)
+	h := sha256.New()
+	h.Write([]byte(u.UserName))
+	guid := base64.StdEncoding.EncodeToString(h.Sum(nil))
+
+	log.Printf("scim: adding %s as %s", u.UserName, guid)
+
+	u.ID = guid
+	sp.store[guid] = u
+
+	return guid, nil
+}
+
+// Del ...
+func (sp *SCIMProvider) Del(guid string) error {
+	log.Printf("scim: removing %s", guid)
+
+	delete(sp.store, guid)
+
+	return nil
+}
+
+// List ...
+func (sp *SCIMProvider) List() ([]scim.User, error) {
+	list := make([]scim.User, len(sp.store))
+
+	for _, user := range sp.store {
+		list = append(list, user)
+	}
+
+	return list, nil
+}

--- a/cmd/ldap-bridged/internal/sp/main.go
+++ b/cmd/ldap-bridged/internal/sp/main.go
@@ -233,6 +233,7 @@ func NewSCIMProvider(org, token string, dryRun bool) SCIMProvider {
 			baseURL: baseURL,
 			token:   token,
 			org:     org,
+			debug:   true,
 		}
 	}
 

--- a/cmd/ldap-bridged/internal/sp/main.go
+++ b/cmd/ldap-bridged/internal/sp/main.go
@@ -203,31 +203,26 @@ type scimProvider interface {
 // SCIMProvider ...
 type SCIMProvider struct {
 	client *scimProvider
+	cfg    scimProviderConfig
+}
+
+type scimProviderConfig struct {
+	token   string
+	baseURL string
+	org     string
+	dryRun  bool
 }
 
 // NewSCIMProvider ...
-func NewSCIMProvider() SCIMProvider {
-	// configuration
-	token := os.Getenv("TOKEN")
-
-	baseURL := os.Getenv("BASEURL")
+func NewSCIMProvider(org, token string, dryRun bool) SCIMProvider {
+	baseURL := os.Getenv("SCIM_BASEURL")
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
 
-	org := os.Getenv("ORG")
-	if org == "" {
-		org = "idptool"
-	}
-
 	var client scimProvider
 
-	dry := true
-	if os.Getenv("DRY") == "no" {
-		dry = false
-	}
-
-	if dry {
+	if dryRun {
 		client = &fakeAPIClient{
 			store: make(map[string]scim.User),
 		}

--- a/cmd/ldap-bridged/main.go
+++ b/cmd/ldap-bridged/main.go
@@ -259,6 +259,27 @@ func loadConfig() config {
 		},
 		dbPath: "bridge.db",
 	}
+
+	if addr := os.Getenv("LDAP_ADDR"); addr != "" {
+		c.ldap.addr = addr
+	}
+	if bindDn := os.Getenv("LDAP_BIND"); bindDn != "" {
+		c.ldap.bindDn = bindDn
+	}
+	if bindPw := os.Getenv("LDAP_PASS"); bindPw != "" {
+		c.ldap.bindPw = bindPw
+	}
+	if baseDn := os.Getenv("LDAP_BASE"); baseDn != "" {
+		c.ldap.baseDn = baseDn
+	}
+	if group := os.Getenv("LDAP_GROUP"); group != "" {
+		c.ldap.group = group
+	}
+
+	if dbPath := os.Getenv("DB"); dbPath != "" {
+		c.dbPath = dbPath
+	}
+
 	return c
 }
 

--- a/cmd/ldap-bridged/main.go
+++ b/cmd/ldap-bridged/main.go
@@ -299,7 +299,7 @@ func loadConfig() config {
 		c.scim.token = token
 	}
 	if dryRun := os.Getenv("SCIM_DRY"); dryRun != "" {
-		c.scim.dryRun = dryRun == "false"
+		c.scim.dryRun = dryRun != "false"
 	}
 
 	if dbPath := os.Getenv("DB"); dbPath != "" {

--- a/cmd/ldap-bridged/main.go
+++ b/cmd/ldap-bridged/main.go
@@ -34,7 +34,7 @@ func newBridge(idp idp.LDAPProvider, sp sp.SCIMProvider, db *bolt.DB) bridge {
 	}
 }
 
-func (b *bridge) Open() error {
+func (b *bridge) Init() error {
 	b.users = users.New(b.db)
 	b.users.Prepare()
 
@@ -173,7 +173,7 @@ func main() {
 	sp := sp.NewSCIMProvider()
 	b := newBridge(lb, sp, db)
 
-	if err = b.Open(); err != nil {
+	if err = b.Init(); err != nil {
 		log.Fatal(err)
 	}
 

--- a/cmd/ldap-bridged/main.go
+++ b/cmd/ldap-bridged/main.go
@@ -189,6 +189,11 @@ func (b *bridge) Del(dn string) {
 		log.Printf("remove: %s failed: %s", guid, err)
 		return
 	}
+
+	if err = b.users.Del(guid, dn); err != nil {
+		log.Printf("remove: bridge store failed: %s", err)
+		return
+	}
 }
 
 // mapEntry takes an LDAP entry, maps to a SCIM user representation

--- a/cmd/ldap-bridged/main.go
+++ b/cmd/ldap-bridged/main.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/mtodd/ldapwatch"
+
+	ldap "gopkg.in/ldap.v2"
+)
+
+type event struct {
+	before *ldap.Entry
+	after  *ldap.Entry
+}
+
+// Implements the ldapwatch.Checker interface in order to check whether
+// the search results change over time.
+//
+// In this case, our Checker keeps track of previous results as well as
+// holding a channel that we notify whenever changes are detected.
+type groupMembershipChecker struct {
+	prev *ldap.SearchResult
+	c    chan event
+}
+
+// Check receives the result of the search; the Checker needs to take action
+// if the result does not match what it expects.
+func (c *groupMembershipChecker) Check(r *ldap.SearchResult, err error) {
+	if err != nil {
+		log.Printf("%s", err)
+		return
+	}
+
+	// first search sets baseline
+	if c.prev == nil {
+		c.prev = r
+		r.PrettyPrint(2)
+		return
+	}
+
+	if len(c.prev.Entries) != len(r.Entries) {
+		// entries returned does not match
+		c.prev = r
+		return
+	}
+
+	prevEntry := c.prev.Entries[0]
+	nextEntry := r.Entries[0]
+
+	if prevEntry.GetAttributeValue("modifyTimestamp") != nextEntry.GetAttributeValue("modifyTimestamp") {
+		// modifyTimestamp changed
+		c.prev = r
+		c.c <- event{prevEntry, nextEntry}
+		return
+	}
+
+	// no change
+}
+
+type changes struct {
+	added   []string
+	removed []string
+}
+
+func computeChanges(before *ldap.Entry, after *ldap.Entry) changes {
+	c := changes{}
+
+	bs := make(map[string]bool, len(before.GetAttributeValues("member")))
+	as := make(map[string]bool, len(after.GetAttributeValues("member")))
+
+	for _, dn := range before.GetAttributeValues("member") {
+		bs[dn] = true
+	}
+	for _, dn := range after.GetAttributeValues("member") {
+		as[dn] = true
+	}
+
+	added := make(map[string]bool, len(before.GetAttributeValues("member")))
+	removed := make(map[string]bool, len(after.GetAttributeValues("member")))
+
+	for dn := range as {
+		// everything in the after list could've been added
+		added[dn] = true
+	}
+	for dn := range bs {
+		// it wasn't added if it was in the before list, so remove it
+		delete(added, dn)
+	}
+
+	for dn := range added {
+		c.added = append(c.added, dn)
+	}
+
+	for dn := range bs {
+		// everything in the before list could've been removed
+		removed[dn] = true
+	}
+	for dn := range as {
+		// it wasn't removed if it was in the after list, so remove it
+		delete(removed, dn)
+	}
+
+	for dn := range removed {
+		c.removed = append(c.removed, dn)
+	}
+
+	return c
+}
+
+func handleUpdates(c chan event, done chan struct{}) {
+	for {
+		select {
+		case e := <-c:
+			before := e.before
+			after := e.after
+			log.Printf("change detected: %s", after.DN)
+			c := computeChanges(before, after)
+			log.Printf("%+v", c)
+		case <-done:
+			return
+		}
+	}
+}
+
+func main() {
+	conn, err := ldap.Dial("tcp", "localhost:389")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+
+	if err = conn.Bind("cn=admin,dc=planetexpress,dc=com", "GoodNewsEveryone"); err != nil {
+		log.Fatal(err)
+	}
+
+	updates := make(chan event)
+	done := make(chan struct{})
+	defer func() { close(done) }()
+	go handleUpdates(updates, done)
+
+	w, err := ldapwatch.NewWatcher(conn, 1*time.Second, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer w.Stop()
+
+	c := groupMembershipChecker{
+		c: updates,
+	}
+
+	// Search to monitor for changes
+	searchRequest := ldap.NewSearchRequest(
+		"ou=people,dc=planetexpress,dc=com",
+		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+		// "(cn=ship_crew)",
+		"(cn=test_group)",
+		[]string{"*", "modifyTimestamp"},
+		nil,
+	)
+
+	// register the search
+	w.Add(searchRequest, &c)
+
+	// run until SIGINT is triggered
+	term := make(chan os.Signal, 1)
+	signal.Notify(term, os.Interrupt)
+
+	w.Start()
+
+	<-term
+}


### PR DESCRIPTION
🚧 WIP: This PR is still in early development stages 🚧 

This PR starts the implementation of the LDAP-to-SCIM bridge daemon.

This daemon is intended to monitor specific LDAP groups and members for updates that should be reflected in the associated service provider. For example, a user must be a member of an LDAP Group to have access to a service provider, so group membership is monitored for changes and reflected to the service provider.

Local storage (thinking BoltDB) is used to preserve the GUIDs (`id`) defined by the service providers during provisioning as subsequent calls (to deprovision) rely on that GUID.

- [x] implement SCIM provisioning/deprovisioning API calls (check out ~~https://github.com/davidiamyou/go-scim~~ https://github.com/imulab/go-scim otherwise hack it)
- [ ] define `identityProvider`, `serviceProvider` behaviors
- [x] design, implement IdP-SP persistence scheme (for lookups by GUID, membership tracking, etc; consider event sourcing/audit)
- [ ] consider configuration format (configure identity provider with LDAP adapter with N number of services; JSON/YAML?)
- [ ] ...?

cc @osowskit 
